### PR TITLE
Improve toArray performance for empty primitive hash sets and maps.

### DIFF
--- a/templates/gnu/trove/map/hash/_K__V_HashMap.template
+++ b/templates/gnu/trove/map/hash/_K__V_HashMap.template
@@ -310,6 +310,9 @@ public class T#K##V#HashMap extends T#K##V#Hash implements T#K##V#Map, Externali
     @Override
     public #k#[] keys() {
         #k#[] keys = new #k#[size()];
+        if ( keys.length == 0 ) {
+            return keys;        // nothing to copy
+        }
         #k#[] k = _set;
         byte[] states = _states;
 
@@ -326,6 +329,9 @@ public class T#K##V#HashMap extends T#K##V#Hash implements T#K##V#Map, Externali
     @Override
     public #k#[] keys( #k#[] array ) {
         int size = size();
+        if ( size == 0 ) {
+            return array;       // nothing to copy
+        }
         if ( array.length < size ) {
             array = new #k#[size];
         }
@@ -353,6 +359,9 @@ public class T#K##V#HashMap extends T#K##V#Hash implements T#K##V#Map, Externali
     @Override
     public #v#[] values() {
         #v#[] vals = new #v#[size()];
+        if ( vals.length == 0 ) {
+            return vals;        // nothing to copy
+        }
         #v#[] v = _values;
         byte[] states = _states;
 
@@ -369,6 +378,9 @@ public class T#K##V#HashMap extends T#K##V#Hash implements T#K##V#Map, Externali
     @Override
     public #v#[] values( #v#[] array ) {
         int size = size();
+        if ( size == 0 ) {
+            return array;       // nothing to copy
+        }
         if ( array.length < size ) {
             array = new #v#[size];
         }

--- a/templates/gnu/trove/set/hash/_E_HashSet.template
+++ b/templates/gnu/trove/set/hash/_E_HashSet.template
@@ -161,6 +161,9 @@ public class T#E#HashSet extends T#E#Hash implements T#E#Set, Externalizable {
     @Override
     public #e#[] toArray() {
         #e#[] result = new #e#[ size() ];
+        if ( result.length == 0 ) {
+            return result;      // nothing to copy
+        }
         #e#[] set = _set;
         byte[] states = _states;
 
@@ -176,6 +179,9 @@ public class T#E#HashSet extends T#E#Hash implements T#E#Set, Externalizable {
     /** {@inheritDoc} */
     @Override
     public #e#[] toArray( #e#[] dest ) {
+        if ( dest.length == 0 ) {
+            return dest;        // nothing to copy
+        }
         #e#[] set = _set;
         byte[] states = _states;
 


### PR DESCRIPTION
While analyzing some code for performance bottlenecks, I noticed that
TLongHashSet.toArray() for empty sets was spinning through a lot of CPU
iterating through all of the states, even though the colleciton was empty. This
change short circuits toArray to return the empty array for empty collections,
giving a roughly 50% increase in performance for empty collections, while
maintaining performance for non-empty collections.

JMH benchmarks for before/after comparison of TIntHashSet.toArray() for varying
sizes of sets of 0, 1, 10, and 100 elements.

Before changes (baseline):

```
Benchmark                               Mode Thr    Cnt  Sec         Mean   Mean error    Units
g.t.b.ToArrayBenchmark.toArray_0000    thrpt   1      5    2        0.049        0.005   ops/ns
g.t.b.ToArrayBenchmark.toArray_0001    thrpt   1      5    2        0.045        0.004   ops/ns
g.t.b.ToArrayBenchmark.toArray_0010    thrpt   1      5    2        0.018        0.001   ops/ns
g.t.b.ToArrayBenchmark.toArray_0100    thrpt   1      5    2        0.002        0.000   ops/ns
g.t.b.ToArrayBenchmark.toArray_0000     avgt   1      5    2       20.115        0.517    ns/op
g.t.b.ToArrayBenchmark.toArray_0001     avgt   1      5    2       21.412        1.070    ns/op
g.t.b.ToArrayBenchmark.toArray_0010     avgt   1      5    2       53.599        1.597    ns/op
g.t.b.ToArrayBenchmark.toArray_0100     avgt   1      5    2      453.046       41.071    ns/op
```

After changes:

```
Benchmark                               Mode Thr    Cnt  Sec         Mean   Mean error    Units
g.t.b.ToArrayBenchmark.toArray_0000    thrpt   1      5    2        0.074        0.002   ops/ns
g.t.b.ToArrayBenchmark.toArray_0001    thrpt   1      5    2        0.047        0.001   ops/ns
g.t.b.ToArrayBenchmark.toArray_0010    thrpt   1      5    2        0.018        0.001   ops/ns
g.t.b.ToArrayBenchmark.toArray_0100    thrpt   1      5    2        0.002        0.000   ops/ns
g.t.b.ToArrayBenchmark.toArray_0000     avgt   1      5    2       13.415        0.353    ns/op
g.t.b.ToArrayBenchmark.toArray_0001     avgt   1      5    2       21.666        0.856    ns/op
g.t.b.ToArrayBenchmark.toArray_0010     avgt   1      5    2       54.996        1.836    ns/op
g.t.b.ToArrayBenchmark.toArray_0100     avgt   1      5    2      443.527       13.193    ns/op
```

cherry-pick of upstream commit 3e91f4414c88143d24bd2ff0d750e631e2ef653c,
see https://bitbucket.org/trove4j/trove/pull-requests/2
