### PR TITLE
Ensure capacity for T*ArrayList.addAll

### DIFF
--- a/templates/gnu/trove/list/array/_E_ArrayList.template
+++ b/templates/gnu/trove/list/array/_E_ArrayList.template
@@ -499,6 +499,7 @@ public class T#E#ArrayList implements T#E#List, Externalizable {
     @Override
     public boolean addAll( Collection<? extends #ET#> collection ) {
         boolean changed = false;
+        ensureCapacity( _pos + collection.size() );
         for ( #ET# element : collection ) {
             #e# e = element.#e#Value();
             if ( add( e ) ) {
@@ -513,6 +514,7 @@ public class T#E#ArrayList implements T#E#List, Externalizable {
     @Override
     public boolean addAll( T#E#Collection collection ) {
         boolean changed = false;
+        ensureCapacity( _pos + collection.size() );
         T#E#Iterator iter = collection.iterator();
         while ( iter.hasNext() ) {
             #e# element = iter.next();
@@ -528,6 +530,7 @@ public class T#E#ArrayList implements T#E#List, Externalizable {
     @Override
     public boolean addAll( #e#[] array ) {
         boolean changed = false;
+        ensureCapacity( _pos + array.length );
         for ( #e# element : array ) {
             if ( add( element ) ) {
                 changed = true;

--- a/templates/gnu/trove/list/array/_E_OffheapArrayList.template
+++ b/templates/gnu/trove/list/array/_E_OffheapArrayList.template
@@ -339,6 +339,7 @@ public class T#E#OffheapArrayList implements T#E#List, Externalizable {
     @Override
     public boolean addAll( Collection<? extends #ET#> collection ) {
         boolean changed = false;
+        ensureCapacity( _pos + collection.size() );
         for ( #ET# element : collection ) {
             #e# e = element.#e#Value();
             if ( add( e ) ) {
@@ -353,6 +354,7 @@ public class T#E#OffheapArrayList implements T#E#List, Externalizable {
     @Override
     public boolean addAll( T#E#Collection collection ) {
         boolean changed = false;
+        ensureCapacity( _pos + collection.size() );
         T#E#Iterator iter = collection.iterator();
         while ( iter.hasNext() ) {
             #e# element = iter.next();
@@ -368,6 +370,7 @@ public class T#E#OffheapArrayList implements T#E#List, Externalizable {
     @Override
     public boolean addAll( #e#[] array ) {
         boolean changed = false;
+        ensureCapacity( _pos + array.length );
         for ( #e# element : array ) {
             if ( add( element ) ) {
                 changed = true;


### PR DESCRIPTION
When adding many entries to T*ArrayList, ensure the capacity before adding all entries.

Upstream PR https://bitbucket.org/trove4j/trove/pull-requests/5
