### PR TITLE
Make AbstractOffHeapArray Java 9+ compatible.

### DIFF
--- a/src/gnu/trove/array/AbstractOffheapArray.java
+++ b/src/gnu/trove/array/AbstractOffheapArray.java
@@ -98,7 +98,7 @@ public abstract class AbstractOffheapArray {
 
         // Cleaner is guaranteed to run its runnable at most once, so its fine to
         // call free multiple times, and nothing additional will happen when this
-        // array becomes unreachable.`
+        // array becomes unreachable.
         clean();
     }
 

--- a/src/gnu/trove/array/AbstractOffheapArray.java
+++ b/src/gnu/trove/array/AbstractOffheapArray.java
@@ -161,7 +161,11 @@ public abstract class AbstractOffheapArray {
         }
     }
 
-    private static void initializeCreateMethod() {
+    private static synchronized void initializeCreateMethod() {
+        if (createMethod != null) {
+            return;
+        }
+
         try {
             Class<?> cleaner = Class.forName("sun.misc.Cleaner");
             createMethod = cleaner.getMethod("create", Object.class, Runnable.class);
@@ -189,7 +193,11 @@ public abstract class AbstractOffheapArray {
         }
     }
 
-    private static void initializeCleanMethod() {
+    private static synchronized void initializeCleanMethod() {
+        if (cleanMethod != null) {
+            return;
+        }
+
         try {
             Class<?> cleanerClass = Class.forName("sun.misc.Cleaner");
             cleanMethod = cleanerClass.getMethod("clean");


### PR DESCRIPTION
Java 9 moved sun.misc.Cleaner to jdk.internal.ref.Cleaner. In order
for this library to be compatible with both Java 8 and Java 9+
runtimes, we need to decide between those at runtime, which
unfortunately means using reflection.

It is worth noting that in Java 9 there was also a public API
introduced for using a cleaner (at java.lang.ref.Cleaner), but that
API is a bit more involved and so it isn't really worth using via
reflection as of right now. If this library ever upgrades to Java 9+
compatibility only, then all this reflection stuff should be replaced
with that instead of the jdk.internal.ref.Cleaner.