### PR TITLE
Move to using public Cleaner in Java 9+.

### DIFF
--- a/src/gnu/trove/array/AbstractOffheapArray.java
+++ b/src/gnu/trove/array/AbstractOffheapArray.java
@@ -18,7 +18,7 @@ import sun.misc.Unsafe;
 public abstract class AbstractOffheapArray {
     protected static final Unsafe UNSAFE;
 
-    private static final Method createMethod = initializeCreateMethod();
+    private static final CleanerCreateMethod createMethod = initializeCreateMethod();
     private static final Method cleanMethod = initializeCleanMethod();
 
     private static class Deallocator implements Runnable {
@@ -46,9 +46,8 @@ public abstract class AbstractOffheapArray {
      * http://grepcode.com/file/repository.grepcode.com/java/root/jdk/openjdk/6-b14/sun/misc/Cleaner.java
      *
      * Need to keep it as a generic Object so that it can be assigned a type at runtime using reflection.
-     * Unfortunately, starting with Java 9, sun.misc.Cleaner moved to jdk.internal.ref.Cleaner, so in
-     * order for this library to be usable for both Java 8 and Java 9+, it must be able to decide which
-     * to use at runtime.
+     * Unfortunately, starting with Java 9, sun.misc.Cleaner moved to java.lang.ref.Cleaner, so in order
+     * for this library to be usable for both Java 8 and Java 9+, it must be able to decide at runtime.
      */
     private final Object cleaner;
     private final AtomicLong boxedAddress;
@@ -156,7 +155,7 @@ public abstract class AbstractOffheapArray {
         }
 
         try {
-            return createMethod.invoke(null, obj, cleanUpRunnable);
+            return createMethod.method.invoke(createMethod.instance, obj, cleanUpRunnable);
         } catch (ReflectiveOperationException e) {
             throw new IllegalStateException("Could not create a new cleaner.", e);
         }
@@ -174,23 +173,28 @@ public abstract class AbstractOffheapArray {
         }
     }
 
-    private static Method initializeCreateMethod() {
+    private static CleanerCreateMethod initializeCreateMethod() {
+        // Java 8
         try {
             Class<?> cleaner = Class.forName("sun.misc.Cleaner");
-            return cleaner.getMethod("create", Object.class, Runnable.class);
+            return new CleanerCreateMethod(cleaner.getMethod("create", Object.class, Runnable.class), null);
         } catch (ReflectiveOperationException e) {
             // means we are on java 9+, try different class
         }
 
+        // Java 9+
         try {
-            Class<?> cleaner = Class.forName("jdk.internal.ref.Cleaner");
-            return cleaner.getMethod("create", Object.class, Runnable.class);
+            Class<?> cleaner = Class.forName("java.lang.ref.Cleaner");
+            Method create = cleaner.getMethod("create");
+            Object cleanerInstance = create.invoke(null);
+            return new CleanerCreateMethod(cleaner.getMethod("register", Object.class, Runnable.class), cleanerInstance);
         } catch (ReflectiveOperationException e) {
             return null;
         }
     }
 
     private static Method initializeCleanMethod() {
+        // Java 8
         try {
             Class<?> cleanerClass = Class.forName("sun.misc.Cleaner");
             return cleanerClass.getMethod("clean");
@@ -198,11 +202,28 @@ public abstract class AbstractOffheapArray {
             // means we are on java 9+, try different class
         }
 
+        // Java 9+
         try {
-            Class<?> cleanerClass = Class.forName("jdk.internal.ref.Cleaner");
+            Class<?> cleanerClass = Class.forName("java.lang.ref.Cleaner$Cleanable");
             return cleanerClass.getMethod("clean");
         } catch (ReflectiveOperationException e) {
             return null;
+        }
+    }
+
+    /**
+     * In Java 9+ the thing we actually want to create is an instance of a
+     * Cleaner.Cleanable, not a Cleaner itself. As such, we actually need
+     * an instance of the Cleaner, so we create this stub class to hold both
+     * pieces of data.
+     */
+    private static class CleanerCreateMethod {
+        final Method method;
+        final Object instance;
+
+        private CleanerCreateMethod(Method method, Object instance) {
+            this.method = method;
+            this.instance = instance;
         }
     }
 }


### PR DESCRIPTION
It turns out the jdk.internal.ref.Cleaner is not publicly accessible,
so we cannot use it as a replacement in Java 9+. As such, we can just
use the public version of the Cleaner, which is a bit more complicated
with reflection, but prepares us better for when this eventually drops
Java 8- support.